### PR TITLE
Migrate to aiohttp request and responses

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@
 __pycache__/
 *.py[cod]
 *$py.class
+.mypy_cache/
+.pytest_cache/
+.venv/
 
 #vscode
 .vscode/

--- a/README.md
+++ b/README.md
@@ -8,7 +8,15 @@ This custom integration is NOT a replacement for the HA Enphase Envoy integratio
 
 You should only deploy this custom integration when running an Enphase Envoy legacy model with firmware before 3.9, either stand-alone or in a mixed environment with newer models. The registered updater is only used for communication to the legacy Envoy, not for communication to the newer models.
 
-Only use with Home Assistant 2023.12 or newer.
+## Releases
+
+### 1.x.x
+
+As of Home Assistant version 2025.? the Enphase Envoy integration switched from using httpx library to using the aiohttp library. Which is a breaking change for this custom integration. Starting with Home Assistant 2025.? you must update to 1.0.0 or newer version.
+
+### 0.1.x
+
+First production versions. Only use with Home Assistant versions from 2023.12 to 2025.?-1.x.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ You should only deploy this custom integration when running an Enphase Envoy leg
 
 ### 1.x.x
 
-As of Home Assistant version 2025.? the Enphase Envoy integration switched from using httpx library to using the aiohttp library. Which is a breaking change for this custom integration. Starting with Home Assistant 2025.? you must update to 1.0.0 or newer version.
+As of Home Assistant version 2025.7, the Enphase Envoy integration switched from using httpx library to using the aiohttp library. This is a breaking change for this custom integration. Starting with Home Assistant 2025.7 you must update this custom integration to 1.0.0 or newer.
 
 ### 0.1.x
 

--- a/custom_components/enphase_envoy_legacy_support/legacy_updater.py
+++ b/custom_components/enphase_envoy_legacy_support/legacy_updater.py
@@ -61,7 +61,7 @@ class LegacyProductionScraper(EnvoyUpdater):
             return None
         try:
             response = await self._probe_request(URL_PRODUCTION)
-            data = response.text
+            data = await response.text()
         except ENDPOINT_PROBE_EXCEPTIONS:
             return None
         # text should contain some key words to validate
@@ -74,7 +74,7 @@ class LegacyProductionScraper(EnvoyUpdater):
     async def update(self, envoy_data: EnvoyData) -> None:
         """Provide the Envoy Production data from the legacy HTML Page."""
         response = await self._request(URL_PRODUCTION)
-        production_data = response.text
+        production_data = await response.text()
         envoy_data.raw[URL_PRODUCTION] = production_data
         envoy_data.system_production = (
             LegacyEnvoySystemProduction.from_production_legacy(production_data)


### PR DESCRIPTION
As of Home assistant version 2025.? the [enphase_envoy integration switched from using httpx to aiohttp](https://github.com/home-assistant/core/pull/146283) in the underlying [pyenphase library](https://github.com/pyenphase/pyenphase/releases). As we use the same library we need to migrate to aiohttp as well.

This is a breaking change. When upgrading Home Assistant to the version that includes the fore-mentioned change, this custom integration must be upgraded as well. And only then, before such an update this custom integration should not be upgraded yet.

There is no functional change for the user.